### PR TITLE
Revised p-value computation in circ_otest for greater numerical stability

### DIFF
--- a/circ_otest.m
+++ b/circ_otest.m
@@ -1,4 +1,4 @@
-function [pval m] = circ_otest(alpha, sz, w)
+function [pval, m] = circ_otest(alpha, sz, w)
 %
 % [pval, m] = circ_otest(alpha,sz,w)
 %   Computes Omnibus or Hodges-Ajne test for non-uniformity of circular data.
@@ -6,7 +6,7 @@ function [pval m] = circ_otest(alpha, sz, w)
 %   HA: the population is not distributed uniformly around the circle
 %
 %   Alternative to the Rayleigh and Rao's test. Works well for unimodal,
-%   bimodal or multimodal data. If requirements of the Rayleigh test are 
+%   bimodal or multimodal data. If requirements of the Rayleigh test are
 %   met, the latter is more powerful.
 %
 %   Input:
@@ -15,7 +15,7 @@ function [pval m] = circ_otest(alpha, sz, w)
 %     [w		number of incidences in case of binned angle data]
 
 %   Output:
-%     pval  p-value 
+%     pval  p-value
 %     m     minimum number of samples falling in one half of the circle
 %
 % PHB 3/16/2009
@@ -31,20 +31,20 @@ function [pval m] = circ_otest(alpha, sz, w)
 % berens@tuebingen.mpg.de - www.kyb.mpg.de/~berens/circStat.html
 
 if size(alpha,2) > size(alpha,1)
-	alpha = alpha';
+    alpha = alpha';
 end
 
 if nargin < 2 || isempty(sz)
-  sz = circ_ang2rad(1);
+    sz = circ_ang2rad(1);
 end
 
 if nargin < 3
-  w = ones(size(alpha));
+    w = ones(size(alpha));
 else
-  if length(alpha)~=length(w)
-    error('Input length does not match.')
-  end
-  w =w(:);  
+    if length(alpha)~=length(w)
+        error('Input length does not match.')
+    end
+    w =w(:);
 end
 
 alpha = mod(alpha,2*pi);
@@ -54,28 +54,12 @@ dg = 0:sz:pi;
 m1 = zeros(size(dg));
 m2 = zeros(size(dg));
 for i=1:length(dg)
-  m1(i) = sum((alpha > dg(i) & alpha < pi + dg(i)).*w);    
-  m2(i) = n - m1(i);
+    m1(i) = sum((alpha > dg(i) & alpha < pi + dg(i)).*w);
+    m2(i) = n - m1(i);
 end
 m = min(min([m1;m2]));
 
-if n > 50
-  % approximation by Ajne (1968)
-  A = pi*sqrt(n) / 2 / (n-2*m);
-  pval = sqrt(2*pi) / A * exp(-pi^2/8/A^2);
-else
-  % exact formula by Hodges (1955)
-  pval = 2^(1-n) * (n-2*m) * nchoosek(n,m);  
+% exact formula by Hodges (1955)
+% revision (for numerical stability) of pval = 2^(1-n) * (n-2*m) * nchoosek(n,m);
+pval = exp((1-n)*log(2) + log(n-2*m) + gammaln(n+1) - gammaln(m+1) - gammaln(n-m+1));
 end
-
-  
-  
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
By expressing the binomial coefficient in terms of the logarithm of the gamma function, Hodges' exact formula for the p-value may be used reliably for sample sizes up to at least n = 10^7, if not greater. For n < 50, the domain for which the exact formula was previously used, the implementation using gammaln to compute the binomial coefficients agrees with that using nchoosek. This should address issues such as those encountered by @AoibhinnR using the approximate formula from Ajne (1968), though I cannot reproduce the result of a negative p-value with the example data provided, even with the original code. 