### PR TITLE
Compiling fixes from other forks

### DIFF
--- a/Contents.m
+++ b/Contents.m
@@ -60,4 +60,3 @@
 %
 % Author:
 %   Philipp Berens & Marc J. Velasco, 2009
-

--- a/README.md
+++ b/README.md
@@ -1,4 +1,86 @@
-circstat-matlab
-===============
+CircStat for Matlab
+=======================
 
-Matlab Circular Statistics Toolbox
+Toolbox for circular statistics with Matlab. 
+
+## Authors:
+Philipp Berens & Marc J. Velasco
+
+*Email*: berens@tuebingen.mpg.de
+
+*Homepage*: http://www.kyb.tuebingen.mpg.de/~berens/circStat.html
+
+## Contributors:
+Tal Krasovsky
+
+## Reference:
+P. Berens, CircStat: A Matlab Toolbox for Circular Statistics, Journal of Statistical Software, Volume 31, Issue 10, 2009
+http://www.jstatsoft.org/v31/i10
+
+Please cite this paper when the provided code is used. See licensing terms for details.
+
+## Contents:
+- `circ_r` 				Resultant vector length
+- `circ_mean` 			Mean direction of a sample of circular data
+- `circ_axial`			Mean direction for axial data
+- `circ_median`			Median direction of a sample of circular data
+- `circ_std` 			Dispersion around the mean direction (std, mardia)
+- `circ_var` 			Circular variance
+- `circ_skewness`		Circular skewness
+- `circ_kurtosis`		Circular kurtosis
+- `circ_moment`			Circular p-th moment
+- `circ_dist`			Distances around a circle
+- `circ_dist2`			Pairwise distances around a circle
+- `circ_confmean` 		Confidence intervals for mean direction
+- `circ_stats`			Summary statistics
+
+&nbsp;
+- `circ_rtest`			Rayleigh's test for nonuniformity
+- `circ_otest`			Hodges-Ajne test (omnibus test) for nonuniformity
+- `circ_raotest`		Rao's spacing test for nonuniformity
+- `circ_vtest`			V-Test for nonuniformity with known mean direction
+- `circ_medtest`		Test for median angle
+- `circ_mtest`			One-sample test for specified mean direction
+- `circ_wwtest`			Multi-sample test for equal means, one-factor ANOVA
+- `circ_hktest` 		Two-factor ANOVA
+- `circ_ktest`      	Test for equal concentration parameter
+- `circ_symtest`		Test for symmetry around median angle
+- `circ_kuipertest`	 	Test whether two distributions are identical (like KS test)
+
+&nbsp;
+- `circ_corrcc`			Circular-circular correlation coefficient
+- `circ_corrcl`			Circular-linear correlation coefficient
+
+&nbsp;
+- `circ_kappa` 			Compute concentration parameter of a von Mises distribution
+- `circ_plot`			Visualization for circular data
+- `circ_clust`    		Simple clustering for circular data
+- `circ_samplecdf`	 	Evaluate CDF of a sample of angles
+
+&nbsp;
+- `rad2ang`				Convert radian to angular values
+- `ang2rad`				Convert angular to radian values
+
+All functions take arguments in radians (expect for `ang2rad`). For a detailed description of arguments and outputs consult the help text in the files.
+
+Since 2010, most functions for descriptive statistics can be used in Matlab style matrix computations. As a last argument, add the dimension along which you want to average. This changes the behavior slightly from previous relaeses, in that input is not reshaped anymore into vector format. Per default, all computations are performed columnwise (along dimension 1). If you prefer to use the old functions, for now they are contained in the subdirectory 'old'.
+
+## References:
+- E. Batschelet, Circular Statistics in Biology, Academic Press, 1981
+- N.I. Fisher, Statistical analysis of circular data, Cambridge University Press, 1996
+- S.R. Jammalamadaka et al., Topics in circular statistics, World Scientific, 2001
+- J.H. Zar, Biostatistical Analysis, Prentice Hall, 1999
+
+
+The implementation follows in most cases 'Biostatistical Analysis' and all referenced equations and tables are taken from this book, if not otherwise noted. In some cases, the other books were preferred for implementation was more straightforward for solutions presented there.
+
+If you have suggestions, bugs or feature requests or want to contribute code, please email us.
+
+## Disclaimer:
+All functions in this toolbox were implemented with care and tested on the examples presented in 'Biostatistical Analysis' were possible. Nevertheless, they may contain errors or bugs, which may affect the outcome of your analysis. We do not take responsibility for any harm coming from using this toolbox, neither if it is caused by errors in the software nor if it is caused by its improper application. Please email us any bugs you find.
+
+By Philipp Berens and Marc J. Velasco, 2009
+
+berens@tuebingen.mpg.de , velasco@ccs.fau.edu - www.kyb.mpg.de/~berens/circStat.html
+
+Distributed under Open Source BSD License

--- a/circ_ang2rad.m
+++ b/circ_ang2rad.m
@@ -9,3 +9,4 @@ function alpha = circ_ang2rad(alpha)
 % berens@tuebingen.mpg.de - www.kyb.mpg.de/~berens/circStat.html
 
 alpha = alpha * pi /180;
+end

--- a/circ_axial.m
+++ b/circ_axial.m
@@ -27,3 +27,4 @@ if nargin < 2
 end
 
 alpha = mod(alpha*p,2*pi);
+end

--- a/circ_axial.m
+++ b/circ_axial.m
@@ -20,7 +20,7 @@ function alpha = circ_axial(alpha, p)
 % By Philipp Berens, 2009
 % berens@tuebingen.mpg.de - www.kyb.mpg.de/~berens/circStat.html
 
-% TESTING GIT
+
 
 if nargin < 2
     p = 1;

--- a/circ_axialmean.m
+++ b/circ_axialmean.m
@@ -1,4 +1,4 @@
-function [r mu] = circ_axialmean(alphas, m, dim)
+function [r, mu] = circ_axialmean(alphas, m, dim)
 %
 % mu = circ_axialmean(alpha, w)
 %   Computes the mean direction for circular data with axial 
@@ -7,7 +7,7 @@ function [r mu] = circ_axialmean(alphas, m, dim)
 %   Input:
 %     alpha	sample of angles in radians
 %     [m		axial correction (2,3,4,...)]
-%     [dim      statistic computed along this dimension, 1]
+%     [dim      statistic computed along this dimension, default: 1st non-singular dimension]
 %
 %   Output:
 %     r		mean resultant length
@@ -27,7 +27,10 @@ function [r mu] = circ_axialmean(alphas, m, dim)
 % Distributed under Open Source BSD License
 
 if nargin < 3
-  dim = 1;
+  dim = find(size(alphas) > 1, 1, 'first');
+  if isempty(dim)
+    dim = 1;
+  end
 end
 
 if nargin < 2 || isempty(m)
@@ -38,4 +41,4 @@ zbarm = mean(exp(1i*alphas*m),dim);
 
 r = abs(zbarm);
 mu = angle(zbarm)/m;
-
+end

--- a/circ_clust.m
+++ b/circ_clust.m
@@ -138,7 +138,7 @@ figure(figurenum);
 colors={'y', 'b', 'r', 'g', 'c', 'k', 'm'};
 
 hold on;
-for j=1:length(csmall);
+for j=1:length(csmall)
     
    ci = (c == csmall(j));
    plot(x(ci), y(ci), strcat(pstring, colors{mod(j, length(colors))+1}), 'MarkerSize', ms);
@@ -146,6 +146,5 @@ for j=1:length(csmall);
 end
 if ~overlay, hold off; end
 figure(figurenum)
-
-
-
+end
+end

--- a/circ_cmtest.m
+++ b/circ_cmtest.m
@@ -55,7 +55,8 @@ for t=1:s
 end
 
 if any(n<10)
-  warning('Test not applicable. Sample size in at least one group to small.') %#ok<WNTAG>
+  warning('CIRCSTAT:circ_cmtest:sampleSizeTooSmall', ...
+      'Test not applicable. Sample size in at least one group too small.') %#ok<WNTAG>
 end
   
 

--- a/circ_cmtest.m
+++ b/circ_cmtest.m
@@ -1,4 +1,4 @@
-function [pval med P] = circ_cmtest(varargin)
+function [pval, med, P] = circ_cmtest(varargin)
 %
 % [pval, med, P] = circ_cmtest(alpha, idx)
 % [pval, med, P] = circ_cmtest(alpha1, alpha2)
@@ -68,7 +68,7 @@ pval = 1 - chi2cdf(P,s-1);
 if pval < 0.05
   med = NaN;
 end
-
+end
 
 
 
@@ -88,4 +88,4 @@ elseif nargin==2
 else
   error('Invalid use of circ_wwtest. Type help circ_wwtest.')
 end
-
+end

--- a/circ_confmean.m
+++ b/circ_confmean.m
@@ -10,7 +10,7 @@ function t = circ_confmean(alpha, xi, w, d, dim)
 %     [d    spacing of bin centers for binned data, if supplied 
 %           correction factor is used to correct for bias in 
 %           estimation of r, in radians (!)]
-%     [dim  compute along this dimension, default is 1]
+%     [dim  compute along this dimension, default: 1st non-singular dimension]
 %
 %   Output:
 %     t     mean +- d yields upper/lower (1-xi)% confidence limit
@@ -28,7 +28,10 @@ function t = circ_confmean(alpha, xi, w, d, dim)
 % berens@tuebingen.mpg.de - www.kyb.mpg.de/~berens/circStat.html
 
 if nargin < 5
-  dim = 1;
+  dim = find(size(alpha) > 1, 1, 'first');
+  if isempty(dim)
+    dim = 1;
+  end
 end
 
 if nargin < 4 || isempty(d)
@@ -74,7 +77,4 @@ end
 
 % apply final transform
 t = acos(t./R);
-  
-
-
-
+end

--- a/circ_confmean.m
+++ b/circ_confmean.m
@@ -67,7 +67,8 @@ for i = 1:numel(r)
     t(i) = sqrt(n(i)^2-(n(i)^2-R(i)^2)*exp(c2/n(i)));      % equ. 26.25
   else 
     t(i) = NaN;
-    warning('Requirements for confidence levels not met.');
+    warning('CIRCSTAT:circ_confmean:requirementsNotMet', ...
+        'Requirements for confidence levels not met.');
   end
 end
 

--- a/circ_corrcc.m
+++ b/circ_corrcc.m
@@ -1,6 +1,6 @@
 function [rho pval] = circ_corrcc(alpha1, alpha2)
 %
-% [rho pval ts] = circ_corrcc(alpha1, alpha2)
+% [rho pval] = circ_corrcc(alpha1, alpha2)
 %   Circular correlation coefficient for two circular random variables.
 %
 %   Input:

--- a/circ_corrcc.m
+++ b/circ_corrcc.m
@@ -1,4 +1,4 @@
-function [rho pval] = circ_corrcc(alpha1, alpha2)
+function [rho, pval] = circ_corrcc(alpha1, alpha2)
 %
 % [rho pval] = circ_corrcc(alpha1, alpha2)
 %   Circular correlation coefficient for two circular random variables.
@@ -50,4 +50,4 @@ l22 = mean((sin(alpha1 - alpha1_bar).^2) .* (sin(alpha2 - alpha2_bar).^2));
 
 ts = sqrt((n * l20 * l02)/l22) * rho;
 pval = 2 * (1 - normcdf(abs(ts)));
-
+end

--- a/circ_corrcl.m
+++ b/circ_corrcl.m
@@ -1,4 +1,4 @@
-function [rho pval] = circ_corrcl(alpha, x)
+function [rho, pval] = circ_corrcl(alpha, x)
 %
 % [rho pval] = circ_corrcc(alpha, x)
 %   Correlation coefficient between one circular and one linear random
@@ -47,4 +47,4 @@ rho = sqrt((rxc^2 + rxs^2 - 2*rxc*rxs*rcs)/(1-rcs^2));
 
 % compute pvalue
 pval = 1 - chi2cdf(n*rho^2,2);
-
+end

--- a/circ_corrcl.m
+++ b/circ_corrcl.m
@@ -1,6 +1,6 @@
 function [rho pval] = circ_corrcl(alpha, x)
 %
-% [rho pval ts] = circ_corrcc(alpha, x)
+% [rho pval] = circ_corrcc(alpha, x)
 %   Correlation coefficient between one circular and one linear random
 %   variable.
 %

--- a/circ_dist.m
+++ b/circ_dist.m
@@ -26,3 +26,4 @@ if size(x,1)~=size(y,1) && size(x,2)~=size(y,2) && length(y)~=1
 end
 
 r = angle(exp(1i*x)./exp(1i*y));
+end

--- a/circ_dist2.m
+++ b/circ_dist2.m
@@ -34,3 +34,4 @@ end
 
 r = angle(repmat(exp(1i*x),1,length(y)) ...
        ./ repmat(exp(1i*y'),length(x),1));
+end

--- a/circ_dist2.m
+++ b/circ_dist2.m
@@ -1,6 +1,6 @@
 function r =  circ_dist2(x,y)
 %
-% r = circ_dist(alpha, beta)
+% r = circ_dist2(alpha, beta)
 %   All pairwise difference x_i-y_j around the circle computed efficiently.
 %
 %   Input:

--- a/circ_hktest.m
+++ b/circ_hktest.m
@@ -1,4 +1,4 @@
-function [pval table] = circ_hktest(alpha, idp, idq, inter, fn)
+function [pval, table] = circ_hktest(alpha, idp, idq, inter, fn)
 
 %
 % [pval, stats] = circ_hktest(alpha, idp, idq, inter, fn)
@@ -238,16 +238,4 @@ prepareOutput;
     end
     
   end
-
-
 end
-
-
-
-
-
-
-
-
-
-

--- a/circ_kappa.m
+++ b/circ_kappa.m
@@ -55,3 +55,4 @@ if N<15 && N>1
     kappa = (N-1)^3*kappa/(N^3+N);
   end
 end
+end

--- a/circ_ktest.m
+++ b/circ_ktest.m
@@ -51,10 +51,4 @@ else
   f = 1/f; 
   pval = 2*(1-fcdf(f, n2, n1));
 end
-
-
-
-
-
-
-
+end

--- a/circ_ktest.m
+++ b/circ_ktest.m
@@ -39,7 +39,8 @@ R2 = n2*circ_r(alpha2);
 rbar = (R1+R2)/(n1+n2);
 
 if rbar < .7
-    warning('resultant vector length should be > 0.7') %#ok<WNTAG>
+    warning('CIRCSTAT:circ_ktest:vectorTooShort', ...
+        'Resultant vector length should be > 0.7') %#ok<WNTAG>
 end
 
 % calculate test statistic

--- a/circ_kuipertest.m
+++ b/circ_kuipertest.m
@@ -45,8 +45,8 @@ n = length(alpha1(:));
 m = length(alpha2(:));
 
 % create cdfs of both samples
-[phis1 cdf1 phiplot1 cdfplot1] = circ_samplecdf(alpha1, res);
-[foo, cdf2 phiplot2 cdfplot2] = circ_samplecdf(alpha2, res); %#ok<ASGLU>
+[phis1, cdf1, phiplot1, cdfplot1] = circ_samplecdf(alpha1, res);
+[foo, cdf2, phiplot2, cdfplot2] = circ_samplecdf(alpha2, res); %#ok<ASGLU>
 
 % maximal difference between sample cdfs
 [dplus, gdpi] = max([0 cdf1-cdf2]);
@@ -56,7 +56,7 @@ m = length(alpha2(:));
 k = n * m * (dplus + dminus);
 
 % find p-value
-[pval K] = kuiperlookup(min(n,m),k/sqrt(n*m*(n+m)));
+[pval, K] = kuiperlookup(min(n,m),k/sqrt(n*m*(n+m)));
 K = K * sqrt(n*m*(n+m));
 
 
@@ -83,14 +83,14 @@ end
 
 end
 
-function [p K] = kuiperlookup(n, k)
+function [p, K] = kuiperlookup(n, k)
 
 load kuipertable.mat;
 alpha = [.10, .05, .02, .01, .005, .002, .001];
 nn = ktable(:,1);  %#ok<NODEF>
 
 % find correct row of the table
-[easy row] = ismember(n, nn);
+[easy, row] = ismember(n, nn);
 if ~easy
    % find closest value if no entry is present)
    row = length(nn) - sum(n<nn); 
@@ -110,5 +110,4 @@ else
   p = 1;
 end
 K = ktable(row,idx+1);
-
 end

--- a/circ_kuipertest.m
+++ b/circ_kuipertest.m
@@ -1,6 +1,6 @@
 function [pval, k, K] = circ_kuipertest(alpha1, alpha2, res, vis_on)
 
-% [pval, k, K] = circ_kuipertest(sample1, sample2, res, vis_on)
+% [pval, k, K] = circ_kuipertest(alpha1, alpha2, res, vis_on)
 %
 %   The Kuiper two-sample test tests whether the two samples differ 
 %   significantly.The difference can be in any property, such as mean 

--- a/circ_kuipertest.m
+++ b/circ_kuipertest.m
@@ -97,7 +97,8 @@ if ~easy
    if row == 0
        error('N too small.');
    else
-      warning('N=%d not found in table, using closest N=%d present.',n,nn(row)) %#ok<WNTAG>
+      warning('CIRCSTAT:circ_kuipertest:nNotFound', ...
+          'N=%d not found in table, using closest N=%d present.',n,nn(row)) %#ok<WNTAG>
    end
 end
 

--- a/circ_kurtosis.m
+++ b/circ_kurtosis.m
@@ -1,4 +1,4 @@
-function [k k0] = circ_kurtosis(alpha, w, dim)
+function [k, k0] = circ_kurtosis(alpha, w, dim)
 
 % [k k0] = circ_kurtosis(alpha,w,dim)
 %   Calculates a measure of angular kurtosis.
@@ -6,7 +6,7 @@ function [k k0] = circ_kurtosis(alpha, w, dim)
 %   Input:
 %     alpha     sample of angles
 %     [w        weightings in case of binned angle data]
-%     [dim      statistic computed along this dimension, 1]
+%     [dim      statistic computed along this dimension, default: 1st non-singular dimension]
 %
 %     If dim argument is specified, all other optional arguments can be
 %     left empty: circ_kurtosis(alpha, [], dim)
@@ -25,7 +25,10 @@ function [k k0] = circ_kurtosis(alpha, w, dim)
 % berens@tuebingen.mpg.de
 
 if nargin < 3
-  dim = 1;
+  dim = find(size(alpha) > 1, 1, 'first');
+  if isempty(dim)
+    dim = 1;
+  end  
 end
 
 if nargin < 2 || isempty(w)
@@ -48,4 +51,5 @@ theta = circ_mean(alpha,w,dim);
 theta2 = repmat(theta, size(alpha)./size(theta));
 k = sum(w.*(cos(2*(circ_dist(alpha,theta2)))),dim)./sum(w,dim);
 k0 = (rho2.*cos(circ_dist(mu2,2*theta))-R.^4)./(1-R).^2;    % (formula 2.30)
+end
 

--- a/circ_mean.m
+++ b/circ_mean.m
@@ -1,6 +1,6 @@
 function [mu ul ll] = circ_mean(alpha, w, dim)
 %
-% mu = circ_mean(alpha, w)
+% [mu ul ll] = circ_mean(alpha, w, dim)
 %   Computes the mean direction for circular data.
 %
 %   Input:

--- a/circ_mean.m
+++ b/circ_mean.m
@@ -1,4 +1,4 @@
-function [mu ul ll] = circ_mean(alpha, w, dim)
+function [mu, ul, ll] = circ_mean(alpha, w, dim)
 %
 % [mu ul ll] = circ_mean(alpha, w, dim)
 %   Computes the mean direction for circular data.
@@ -6,7 +6,7 @@ function [mu ul ll] = circ_mean(alpha, w, dim)
 %   Input:
 %     alpha	sample of angles in radians
 %     [w		weightings in case of binned angle data]
-%     [dim  compute along this dimension, default is 1]
+%     [dim  compute along this dimension, default: 1st non-singular dimension]
 %
 %     If dim argument is specified, all other optional arguments can be
 %     left empty: circ_mean(alpha, [], dim)
@@ -29,7 +29,10 @@ function [mu ul ll] = circ_mean(alpha, w, dim)
 % berens@tuebingen.mpg.de - www.kyb.mpg.de/~berens/circStat.html
 
 if nargin < 3
-  dim = 1;
+  dim = find(size(alpha) > 1, 1, 'first');
+  if isempty(dim)
+    dim = 1;
+  end
 end
 
 if nargin < 2 || isempty(w)
@@ -53,4 +56,5 @@ if nargout > 1
   t = circ_confmean(alpha,0.05,w,[],dim);
   ul = mu + t;
   ll = mu - t;
+end
 end

--- a/circ_median.m
+++ b/circ_median.m
@@ -5,7 +5,7 @@ function med = circ_median(alpha,dim)
 %
 %   Input:
 %     alpha	sample of angles in radians
-%     [dim  compute along this dimension, default is 1, must 
+%     [dim  compute along this dimension, default: 1st non-singular dimension, must 
 %           be either 1 or 2 for circ_median]
 %
 %   Output:
@@ -25,7 +25,10 @@ function med = circ_median(alpha,dim)
 % berens@tuebingen.mpg.de - www.kyb.mpg.de/~berens/circStat.html
 
 if nargin < 2
-  dim = 1;
+  dim = find(size(alpha) > 1, 1, 'first');
+  if isempty(dim)
+    dim = 1;
+  end  
 end
 
 M = size(alpha);
@@ -48,7 +51,7 @@ for i=1:M(3-dim)
 
   dm = abs(m1-m2);
   if mod(n,2)==1
-    [m idx] = min(dm);
+    [m, idx] = min(dm);
   else
     m = min(dm);
     idx = find(dm==m,2);
@@ -70,4 +73,5 @@ end
 
 if dim == 2
   med = med';
+end
 end

--- a/circ_median.m
+++ b/circ_median.m
@@ -1,6 +1,6 @@
 function med = circ_median(alpha,dim)
 %
-% med = circ_median(alpha)
+% med = circ_median(alpha, dim)
 %   Computes the median direction for circular data.
 %
 %   Input:
@@ -9,7 +9,7 @@ function med = circ_median(alpha,dim)
 %           be either 1 or 2 for circ_median]
 %
 %   Output:
-%     mu		median direction
+%     med		median direction
 %
 %   circ_median can be slow for large datasets
 %

--- a/circ_median.m
+++ b/circ_median.m
@@ -55,7 +55,8 @@ for i=1:M(3-dim)
   end
 
   if m > 1
-    warning('Ties detected.') %#ok<WNTAG>
+    warning('CIRCSTAT:circ_median:tiesDetected', ...
+        'Ties detected.') %#ok<WNTAG>
   end
 
   md = circ_mean(beta(idx));

--- a/circ_medtest.m
+++ b/circ_medtest.m
@@ -1,6 +1,6 @@
 function pval = circ_medtest(alpha,md)
 %
-% [pval, z] = circ_medtest(alpha,w)
+% pval = circ_medtest(alpha, md)
 %   Tests for significance of the median.
 %   H0: the population has median angle md
 %   HA: the population has not median angle md

--- a/circ_medtest.m
+++ b/circ_medtest.m
@@ -40,7 +40,4 @@ n2 = sum(d>0);
 
 % compute p-value with binomial test
 pval = sum(binopdf([0:min(n1,n2) max(n1,n2):n],n,0.5));
-
-
-
-
+end

--- a/circ_moment.m
+++ b/circ_moment.m
@@ -1,6 +1,6 @@
 function [mp  rho_p mu_p] = circ_moment(alpha, w, p, cent, dim)
 
-% [mp cbar sbar] = circ_moment(alpha, w, p, cent, dim)
+% [mp rho_p mu_p] = circ_moment(alpha, w, p, cent, dim)
 %   Calculates the complex p-th centred or non-centred moment 
 %   of the angular data in angle.
 %

--- a/circ_moment.m
+++ b/circ_moment.m
@@ -1,4 +1,4 @@
-function [mp  rho_p mu_p] = circ_moment(alpha, w, p, cent, dim)
+function [mp,  rho_p, mu_p] = circ_moment(alpha, w, p, cent, dim)
 
 % [mp rho_p mu_p] = circ_moment(alpha, w, p, cent, dim)
 %   Calculates the complex p-th centred or non-centred moment 
@@ -9,7 +9,7 @@ function [mp  rho_p mu_p] = circ_moment(alpha, w, p, cent, dim)
 %     [w        weightings in case of binned angle data]
 %     [p        p-th moment to be computed, default is p=1]
 %     [cent     if true, central moments are computed, default = false]
-%     [dim      compute along this dimension, default is 1]
+%     [dim      compute along this dimension, default is 1st non-singular dimension]
 %
 %     If dim argument is specified, all other optional arguments can be
 %     left empty: circ_moment(alpha, [], [], [], dim)
@@ -29,7 +29,10 @@ function [mp  rho_p mu_p] = circ_moment(alpha, w, p, cent, dim)
 % berens@tuebingen.mpg.de
 
 if nargin < 5
-  dim = 1;
+  dim = find(size(alpha) > 1, 1, 'first');
+  if isempty(dim)
+    dim = 1;
+  end
 end
 
 if nargin < 4
@@ -65,5 +68,4 @@ mp = cbar + 1i*sbar;
 
 rho_p = abs(mp);
 mu_p = angle(mp);
-
-
+end

--- a/circ_mtest.m
+++ b/circ_mtest.m
@@ -1,4 +1,4 @@
-function [h mu ul ll] = circ_mtest(alpha, dir, xi, w, d)
+function [h, mu, ul, ll] = circ_mtest(alpha, dir, xi, w, d)
 %
 % [h mu ul ll] = circ_mtest(alpha, dir, xi, w, d)
 %   One-Sample test for the mean angle.
@@ -67,3 +67,4 @@ ll = mu - t;
 
 % compute test via confidence limits (example 27.3)
 h = abs(circ_dist2(dir,mu)) > t;
+end

--- a/circ_mtest.m
+++ b/circ_mtest.m
@@ -1,6 +1,6 @@
 function [h mu ul ll] = circ_mtest(alpha, dir, xi, w, d)
 %
-% [pval, z] = circ_mtest(alpha, dir, w, d)
+% [h mu ul ll] = circ_mtest(alpha, dir, xi, w, d)
 %   One-Sample test for the mean angle.
 %   H0: the population has mean dir.
 %   HA: the population has not mean dir.

--- a/circ_otest.m
+++ b/circ_otest.m
@@ -13,7 +13,7 @@ function [pval m] = circ_otest(alpha, sz, w)
 %     alpha	sample of angles in radians
 %     [sz   step size for evaluating distribution, default 1 degree
 %     [w		number of incidences in case of binned angle data]
-
+%
 %   Output:
 %     pval  p-value 
 %     m     minimum number of samples falling in one half of the circle
@@ -67,15 +67,3 @@ else
   % exact formula by Hodges (1955)
   pval = 2^(1-n) * (n-2*m) * nchoosek(n,m);  
 end
-
-  
-  
-
-
-
-
-
-
-
-
-

--- a/circ_otest.m
+++ b/circ_otest.m
@@ -65,6 +65,7 @@ if n > 50
   pval = sqrt(2*pi) / A * exp(-pi^2/8/A^2);
 else
   % exact formula by Hodges (1955)
-  pval = 2^(1-n) * (n-2*m) * nchoosek(n,m);  
+  % pval = 2^(1-n) * (n-2*m) * nchoosek(n,m);  % revised below for numerical stability
+  pval = exp((1-n)*log(2) + log(n-2*m) + gammaln(n+1) - gammaln(m+1) - gammaln(n-m+1));
 end
 end

--- a/circ_otest.m
+++ b/circ_otest.m
@@ -1,4 +1,4 @@
-function [pval m] = circ_otest(alpha, sz, w)
+function [pval, m] = circ_otest(alpha, sz, w)
 %
 % [pval, m] = circ_otest(alpha,sz,w)
 %   Computes Omnibus or Hodges-Ajne test for non-uniformity of circular data.
@@ -66,4 +66,5 @@ if n > 50
 else
   % exact formula by Hodges (1955)
   pval = 2^(1-n) * (n-2*m) * nchoosek(n,m);  
+end
 end

--- a/circ_plot.m
+++ b/circ_plot.m
@@ -1,6 +1,6 @@
 function a = circ_plot(alpha, format, formats, varargin)
 %
-% r = circ_plot(alpha, ...)
+% a = circ_plot(alpha, ...)
 %   Plotting routines for circular data.
 %
 %   Input:

--- a/circ_plot.m
+++ b/circ_plot.m
@@ -89,7 +89,7 @@ switch format
     set(gca,'box','off')
     set(gca,'xtick',[])
     set(gca,'ytick',[])
-    text(1.2, 0, '0'); text(-.05, 1.2, '\pi/2');  text(-1.35, 0, '±\pi');  text(-.075, -1.2, '-\pi/2');
+    text(1.2, 0, '0'); text(-.05, 1.2, '\pi/2');  text(-1.35, 0, 'ï¿½\pi');  text(-.075, -1.2, '-\pi/2');
 
     
   case 'hist'
@@ -141,3 +141,4 @@ switch format
 end
 
 a = gca;
+end

--- a/circ_r.m
+++ b/circ_r.m
@@ -8,7 +8,7 @@ function r = circ_r(alpha, w, d, dim)
 %     [d    spacing of bin centers for binned data, if supplied 
 %           correction factor is used to correct for bias in 
 %           estimation of r, in radians (!)]
-%     [dim  compute along this dimension, default is 1]
+%     [dim  compute along this dimension, default: 1st non-singular dimension]
 %
 %     If dim argument is specified, all other optional arguments can be
 %     left empty: circ_r(alpha, [], [], dim)
@@ -29,7 +29,10 @@ function r = circ_r(alpha, w, d, dim)
 % berens@tuebingen.mpg.de - www.kyb.mpg.de/~berens/circStat.html
 
 if nargin < 4
-  dim = 1;
+  dim = find(size(alpha) > 1, 1, 'first');
+  if isempty(dim)
+    dim = 1;
+  end
 end
 
 if nargin < 2 || isempty(w) 
@@ -59,4 +62,4 @@ if d ~= 0
   c = d/2/sin(d/2);
   r = c*r;
 end
-
+end

--- a/circ_r.m
+++ b/circ_r.m
@@ -1,5 +1,5 @@
 function r = circ_r(alpha, w, d, dim)
-% r = circ_r(alpha, w, d)
+% r = circ_r(alpha, w, d, dim)
 %   Computes mean resultant vector length for circular data.
 %
 %   Input:

--- a/circ_rad2ang.m
+++ b/circ_rad2ang.m
@@ -9,3 +9,4 @@ function alpha = circ_rad2ang(alpha)
 % berens@tuebingen.mpg.de - www.kyb.mpg.de/~berens/circStat.html
 
 alpha = alpha / pi *180;
+end

--- a/circ_rad2ang.m
+++ b/circ_rad2ang.m
@@ -1,6 +1,6 @@
 function alpha = circ_rad2ang(alpha)
 
-% alpha = circ-rad2ang(alpha)
+% alpha = circ_rad2ang(alpha)
 %   converts values in radians to values in degree
 %
 % Circular Statistics Toolbox for Matlab

--- a/circ_raotest.m
+++ b/circ_raotest.m
@@ -1,4 +1,4 @@
-function [p U UC] = circ_raotest(alpha)
+function [p, U, UC] = circ_raotest(alpha)
 %
 % [p U UC] = circ_raotest(alpha)
 %   Calculates Rao's spacing test by comparing distances between points on
@@ -59,11 +59,11 @@ U = U + abs(tn-lambda);
 U = (1/2)*U;
 
 % get critical value from table
-[p UC] = getVal(n,U);
+[p, UC] = getVal(n,U);
 
 
 
-function [p UC] = getVal(N, U)
+function [p, UC] = getVal(N, U)
 
 % Table II from Russel and Levitin, 1995
 
@@ -122,9 +122,5 @@ else
   UC = table(ridx,end-1);
   p = .5;
 end
-
-
-
-
-
-
+end
+end

--- a/circ_raotest.m
+++ b/circ_raotest.m
@@ -1,5 +1,5 @@
 function [p U UC] = circ_raotest(alpha)
-
+%
 % [p U UC] = circ_raotest(alpha)
 %   Calculates Rao's spacing test by comparing distances between points on
 %   a circle to those expected from a uniform distribution.

--- a/circ_rtest.m
+++ b/circ_rtest.m
@@ -1,4 +1,4 @@
-function [pval z] = circ_rtest(alpha, w, d)
+function [pval, z] = circ_rtest(alpha, w, d)
 %
 % [pval, z] = circ_rtest(alpha,w,d)
 %   Computes Rayleigh test for non-uniformity of circular data.
@@ -65,11 +65,4 @@ pval = exp(sqrt(1+4*n+4*(n^2-R^2))-(1+2*n));
 %    (24*z - 132*z^2 + 76*z^3 - 9*z^4) / (288*n^2));
 % end
 
-
-
-
-
-
-
-
-
+end

--- a/circ_rtest.m
+++ b/circ_rtest.m
@@ -1,6 +1,6 @@
 function [pval z] = circ_rtest(alpha, w, d)
 %
-% [pval, z] = circ_rtest(alpha,w)
+% [pval, z] = circ_rtest(alpha,w,d)
 %   Computes Rayleigh test for non-uniformity of circular data.
 %   H0: the population is uniformly distributed around the circle
 %   HA: the populatoin is not distributed uniformly around the circle

--- a/circ_samplecdf.m
+++ b/circ_samplecdf.m
@@ -60,10 +60,11 @@ cdf2 = [0 cdf(1:end-1)];
 cdfplottable = [];
 phisplottable = [];
 
-for j=1:length(phis);
+for j=1:length(phis)
    phisplottable = [phisplottable phis(j) phis2(j)]; %#ok<AGROW>
    cdfplottable = [cdfplottable cdf2(j) cdf(j)]; %#ok<AGROW>
 end
 
 phiplot = [phisplottable 2*pi];
 cdfplot = [cdfplottable 1];
+end

--- a/circ_samplecdf.m
+++ b/circ_samplecdf.m
@@ -1,5 +1,5 @@
 function [phis, cdf, phiplot, cdfplot] = circ_samplecdf(thetas, resolution)
-
+%
 % [phis, cdf, phiplot, cdfplot] = circ_samplecdf(thetas, resolution)
 %
 %   Helper function for circ_kuipertest.
@@ -67,8 +67,3 @@ end
 
 phiplot = [phisplottable 2*pi];
 cdfplot = [cdfplottable 1];
-
-
-
-
-

--- a/circ_skewness.m
+++ b/circ_skewness.m
@@ -1,5 +1,5 @@
 function [b b0] = circ_skewness(alpha, w, dim)
-
+%
 % [b b0] = circ_skewness(alpha,w,dim)
 %   Calculates a measure of angular skewness.
 %
@@ -48,5 +48,3 @@ theta = circ_mean(alpha,w,dim);
 theta2 = repmat(theta, size(alpha)./size(theta));
 b = sum(w.*(sin(2*(circ_dist(alpha,theta2)))),dim)./sum(w,dim);
 b0 = rho2.*sin(circ_dist(mu2,2*theta))./(1-R).^(3/2);    % (formula 2.29)
-
-

--- a/circ_skewness.m
+++ b/circ_skewness.m
@@ -1,4 +1,4 @@
-function [b b0] = circ_skewness(alpha, w, dim)
+function [b, b0] = circ_skewness(alpha, w, dim)
 %
 % [b b0] = circ_skewness(alpha,w,dim)
 %   Calculates a measure of angular skewness.
@@ -6,7 +6,7 @@ function [b b0] = circ_skewness(alpha, w, dim)
 %   Input:
 %     alpha     sample of angles
 %     [w        weightings in case of binned angle data]
-%     [dim      statistic computed along this dimension, 1]
+%     [dim      statistic computed along this dimension, default: 1st non-singular dimension]
 %
 %     If dim argument is specified, all other optional arguments can be
 %     left empty: circ_skewness(alpha, [], dim)
@@ -25,7 +25,10 @@ function [b b0] = circ_skewness(alpha, w, dim)
 % berens@tuebingen.mpg.de
 
 if nargin < 3
-  dim = 1;
+  dim = find(size(alpha) > 1, 1, 'first');
+  if isempty(dim)
+    dim = 1;
+  end  
 end
 
 if nargin < 2 || isempty(w)
@@ -48,3 +51,4 @@ theta = circ_mean(alpha,w,dim);
 theta2 = repmat(theta, size(alpha)./size(theta));
 b = sum(w.*(sin(2*(circ_dist(alpha,theta2)))),dim)./sum(w,dim);
 b0 = rho2.*sin(circ_dist(mu2,2*theta))./(1-R).^(3/2);    % (formula 2.29)
+end

--- a/circ_stats.m
+++ b/circ_stats.m
@@ -52,11 +52,12 @@ end
 stats.var = circ_var(alpha,w,d);
 
 % standard deviation
-[stats.std stats.std0] = circ_std(alpha,w,d);
+[stats.std, stats.std0] = circ_std(alpha,w,d);
 
 
 % skewness
-[stats.skewness stats.skewness0] = circ_skewness(alpha,w);
+[stats.skewness, stats.skewness0] = circ_skewness(alpha,w);
 
 % kurtosis
-[stats.kurtosis stats.kurtosis0] = circ_kurtosis(alpha,w);
+[stats.kurtosis, stats.kurtosis0] = circ_kurtosis(alpha,w);
+end

--- a/circ_stats.m
+++ b/circ_stats.m
@@ -1,6 +1,6 @@
 function stats = circ_stats(alpha, w, d)
 %
-% stats = circ_stats(alpha, w)
+% stats = circ_stats(alpha, w, d)
 %   Computes descriptive statistics for circular data.
 %
 %   Input:
@@ -60,7 +60,3 @@ stats.var = circ_var(alpha,w,d);
 
 % kurtosis
 [stats.kurtosis stats.kurtosis0] = circ_kurtosis(alpha,w);
-
-
-
-

--- a/circ_std.m
+++ b/circ_std.m
@@ -1,4 +1,4 @@
-function [s s0] = circ_std(alpha, w, d, dim)
+function [s, s0] = circ_std(alpha, w, d, dim)
 % [s, s0] = circ_std(alpha, w, d, dim)
 %   Computes circular standard deviation for circular data 
 %   (equ. 26.20, Zar).   
@@ -9,7 +9,7 @@ function [s s0] = circ_std(alpha, w, d, dim)
 %     [d    spacing of bin centers for binned data, if supplied 
 %           correction factor is used to correct for bias in 
 %           estimation of r]
-%     [dim  compute along this dimension, default is 1]
+%     [dim  compute along this dimension, default: 1st non-singular dimension]
 %
 %     If dim argument is specified, all other optional arguments can be
 %     left empty: circ_std(alpha, [], [], dim)
@@ -29,7 +29,10 @@ function [s s0] = circ_std(alpha, w, d, dim)
 % berens@tuebingen.mpg.de - www.kyb.mpg.de/~berens/circStat.html
 
 if nargin < 4
-  dim = 1;
+  dim = find(size(alpha) > 1, 1, 'first');
+  if isempty(dim)
+    dim = 1;
+  end  
 end
 
 if nargin < 3 || isempty(d)
@@ -51,4 +54,5 @@ end
 r = circ_r(alpha,w,d,dim);
 
 s = sqrt(2*(1-r));      % 26.20
-s0 = sqrt(-2*log(r));    % 26.21
+s0 = sqrt(-2*log(r));   % 26.21
+end

--- a/circ_std.m
+++ b/circ_std.m
@@ -1,5 +1,5 @@
 function [s s0] = circ_std(alpha, w, d, dim)
-% s = circ_std(alpha, w, d, dim)
+% [s, s0] = circ_std(alpha, w, d, dim)
 %   Computes circular standard deviation for circular data 
 %   (equ. 26.20, Zar).   
 %
@@ -52,6 +52,3 @@ r = circ_r(alpha,w,d,dim);
 
 s = sqrt(2*(1-r));      % 26.20
 s0 = sqrt(-2*log(r));    % 26.21
-
-
-

--- a/circ_symtest.m
+++ b/circ_symtest.m
@@ -1,10 +1,10 @@
 function pval = circ_symtest(alpha)
 %
-% [pval, z] = circ_symtest(alpha,w)
+% pval = circ_symtest(alpha)
 %   Tests for symmetry about the median.
 %   H0: the population is symmetrical around the median
 %   HA: the population is not symmetrical around the median
-
+%
 %
 %   Input:
 %     alpha	sample of angles in radians
@@ -34,7 +34,3 @@ d = circ_dist(alpha,md);
 
 % compute wilcoxon sign rank test
 pval = signrank(d);
-
-
-
-

--- a/circ_symtest.m
+++ b/circ_symtest.m
@@ -34,3 +34,4 @@ d = circ_dist(alpha,md);
 
 % compute wilcoxon sign rank test
 pval = signrank(d);
+end

--- a/circ_var.m
+++ b/circ_var.m
@@ -1,5 +1,5 @@
 function [S s] = circ_var(alpha, w, d, dim)
-% s = circ_var(alpha, w, d, dim)
+% [S, s] = circ_var(alpha, w, d, dim)
 %   Computes circular variance for circular data 
 %   (equ. 26.17/18, Zar).   
 %

--- a/circ_var.m
+++ b/circ_var.m
@@ -1,4 +1,4 @@
-function [S s] = circ_var(alpha, w, d, dim)
+function [S, s] = circ_var(alpha, w, d, dim)
 % [S, s] = circ_var(alpha, w, d, dim)
 %   Computes circular variance for circular data 
 %   (equ. 26.17/18, Zar).   
@@ -9,7 +9,7 @@ function [S s] = circ_var(alpha, w, d, dim)
 %     [d    spacing of bin centers for binned data, if supplied 
 %           correction factor is used to correct for bias in 
 %           estimation of r]
-%     [dim  compute along this dimension, default is 1]
+%     [dim  compute along this dimension, default: 1st non-singular dimension]
 %
 %     If dim argument is specified, all other optional arguments can be
 %     left empty: circ_var(alpha, [], [], dim)
@@ -31,7 +31,10 @@ function [S s] = circ_var(alpha, w, d, dim)
 % berens@tuebingen.mpg.de - www.kyb.mpg.de/~berens/circStat.html
 
 if nargin < 4
-  dim = 1;
+  dim = find(size(alpha) > 1, 1, 'first');
+  if isempty(dim)
+    dim = 1;
+  end    
 end
 
 if nargin < 3 || isempty(d)
@@ -55,3 +58,4 @@ r = circ_r(alpha,w,d,dim);
 % apply transformation to var
 S = 1 - r;
 s = 2 * S;
+end

--- a/circ_vmpar.m
+++ b/circ_vmpar.m
@@ -1,6 +1,6 @@
 function [thetahat kappa] = circ_vmpar(alpha,w,d)
-
-% r = circ_vmpar(alpha, w, d)
+%
+% [thetahat, kappa] = circ_vmpar(alpha, w, d)
 %   Estimate the parameters of a von Mises distribution.
 %
 %   Input:

--- a/circ_vmpar.m
+++ b/circ_vmpar.m
@@ -1,4 +1,4 @@
-function [thetahat kappa] = circ_vmpar(alpha,w,d)
+function [thetahat, kappa] = circ_vmpar(alpha,w,d)
 %
 % [thetahat, kappa] = circ_vmpar(alpha, w, d)
 %   Estimate the parameters of a von Mises distribution.
@@ -36,3 +36,4 @@ r = circ_r(alpha,w,d);
 kappa = circ_kappa(r);
 
 thetahat = circ_mean(alpha,w);
+end

--- a/circ_vmpdf.m
+++ b/circ_vmpdf.m
@@ -1,4 +1,4 @@
-function [p alpha] = circ_vmpdf(alpha, thetahat, kappa)
+function [p, alpha] = circ_vmpdf(alpha, thetahat, kappa)
 %
 % [p alpha] = circ_vmpdf(alpha, thetahat, kappa)
 %   Computes the circular von Mises pdf with preferred direction thetahat 
@@ -44,3 +44,4 @@ alpha = alpha(:);
 % evaluate pdf
 C = 1/(2*pi*besseli(0,kappa));
 p = C * exp(kappa*cos(alpha-thetahat));
+end

--- a/circ_vmpdf.m
+++ b/circ_vmpdf.m
@@ -42,6 +42,5 @@ end
 alpha = alpha(:);
 
 % evaluate pdf
-C = 1/(2*pi*besseli(0,kappa));
-p = C * exp(kappa*cos(alpha-thetahat));
+p = exp( kappa*(cos(alpha-thetahat)-1) ) / (2*pi*besseli(0,kappa,1));
 end

--- a/circ_vmpdf.m
+++ b/circ_vmpdf.m
@@ -1,6 +1,6 @@
 function [p alpha] = circ_vmpdf(alpha, thetahat, kappa)
-
-% [p alpha] = circ_vmpdf(alpha, w, p)
+%
+% [p alpha] = circ_vmpdf(alpha, thetahat, kappa)
 %   Computes the circular von Mises pdf with preferred direction thetahat 
 %   and concentration kappa at each of the angles in alpha
 %

--- a/circ_vmrnd.m
+++ b/circ_vmrnd.m
@@ -1,8 +1,8 @@
 function alpha = circ_vmrnd(theta, kappa, n)
-
+%
 % alpha = circ_vmrnd(theta, kappa, n)
 %   Simulates n random angles from a von Mises distribution, with preferred 
-%   direction thetahat and concentration parameter kappa.
+%   direction theta and concentration parameter kappa.
 %
 %   Input:
 %     [theta    preferred direction, default is 0]

--- a/circ_vmrnd.m
+++ b/circ_vmrnd.m
@@ -47,7 +47,7 @@ end
 
 % if kappa is small, treat as uniform distribution
 if kappa < 1e-6
-    alpha = 2*pi*rand(n,1);
+    alpha = 2*pi*rand(n,1)-pi;
     return
 end
 

--- a/circ_vmrnd.m
+++ b/circ_vmrnd.m
@@ -79,9 +79,4 @@ end
 if exist('m','var')
   alpha = reshape(alpha,m(1),m(2));
 end
-
-
-
-
-
-
+end

--- a/circ_vtest.m
+++ b/circ_vtest.m
@@ -1,4 +1,4 @@
-function [pval v] = circ_vtest(alpha, dir, w, d)
+function [pval, v] = circ_vtest(alpha, dir, w, d)
 %
 % [pval, v] = circ_vtest(alpha, dir, w, d)
 %   Computes V test for non-uniformity of circular data with a specified 
@@ -75,3 +75,4 @@ u = v * sqrt(2/n);
 
 % compute p-value from one tailed normal approximation
 pval = 1 - normcdf(u);
+end

--- a/circ_wwtest.m
+++ b/circ_wwtest.m
@@ -1,4 +1,4 @@
-function [pval table] = circ_wwtest(varargin)
+function [pval, table] = circ_wwtest(varargin)
 %
 % [pval, table] = circ_wwtest(alpha, idx, [w])
 % [pval, table] = circ_wwtest(alpha1, alpha2, [w1, w2])

--- a/circ_wwtest.m
+++ b/circ_wwtest.m
@@ -106,13 +106,17 @@ end
 function checkAssumption(rw,n)
 
   if n >= 11 && rw<.45
-    warning('Test not applicable. Average resultant vector length < 0.45.') %#ok<WNTAG>
+    warning('CIRCSTAT:circ_wwtest:vectorTooShort', ...
+        'Test not applicable. Average resultant vector length < 0.45.') %#ok<WNTAG>
   elseif n<11 && n>=7 && rw<.5
-    warning('Test not applicable. Average number of samples per population 6 < x < 11 and average resultant vector length < 0.5.') %#ok<WNTAG>
+    warning('CIRCSTAT:circ_wwtest:sampleSize6x11AndVectorTooShort', ...
+        'Test not applicable. Average number of samples per population 6 < x < 11 and average resultant vector length < 0.5.') %#ok<WNTAG>
   elseif n>=5 && n<7 && rw<.55
-    warning('Test not applicable. Average number of samples per population 4 < x < 7 and average resultant vector length < 0.55.') %#ok<WNTAG>
+    warning('CIRCSTAT:circ_wwtest:sampleSize4x7AndVectorTooShort', ...
+        'Test not applicable. Average number of samples per population 4 < x < 7 and average resultant vector length < 0.55.') %#ok<WNTAG>
   elseif n < 5
-    warning('Test not applicable. Average number of samples per population < 5.') %#ok<WNTAG>
+    warning('CIRCSTAT:circ_wwtest:sampleSizeTooSmall', ...
+        'Test not applicable. Average number of samples per population < 5.') %#ok<WNTAG>
   end
 
 end

--- a/circ_wwtest.m
+++ b/circ_wwtest.m
@@ -1,4 +1,5 @@
 function [pval table] = circ_wwtest(varargin)
+%
 % [pval, table] = circ_wwtest(alpha, idx, [w])
 % [pval, table] = circ_wwtest(alpha1, alpha2, [w1, w2])
 %   Parametric Watson-Williams multi-sample test for equal means. Can be
@@ -159,4 +160,3 @@ function [alpha, idx, w] = processInput(varargin)
     error('Invalid use of circ_wwtest. Type help circ_wwtest.')
   end
 end
-


### PR DESCRIPTION
Added in fixes from other forks.
Addresses:
https://github.com/circstat/circstat-matlab/issues/3 (indirectly, technically the transpose should be removed instead)
https://github.com/circstat/circstat-matlab/issues/6
https://github.com/circstat/circstat-matlab/issues/7
